### PR TITLE
Implement v0.2.0 features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in values
+OPENAI_API_KEY=
+DATABASE_URL=sqlite:///./chat.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.2.0
+- `/chat` now generates answers using the OpenAI API when an `OPENAI_API_KEY` is provided.
+- Added SQLite message persistence with SQLAlchemy.
+- Frontend revamped with chat bubbles, typing indicator and error handling.
+- Added environment variable support via `.env` files.
+- Dockerfiles converted to multi-stage builds and Docker Compose enables hot reloading.
+- Added `.env.example` and updated setup instructions.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # AI Assistant Example
 
-This repository contains a minimal AI assistant example with a FastAPI backend and a Next.js frontend. Both services can be run together using Docker Compose.
+This repository contains a simple AI assistant with a FastAPI backend and a Next.js frontend. Both services run together using Docker Compose.
 
 ## Prerequisites
 - [Docker](https://www.docker.com/get-started)
 - [Docker Compose](https://docs.docker.com/compose/)
 
-## Usage
+## Setup
+1. Copy `.env.example` to `.env` and add your values. Set `OPENAI_API_KEY` if you want real AI responses.
+2. Build and start the services:
+   ```bash
+   docker-compose up --build
+   ```
+3. Access the frontend at [http://localhost:3000](http://localhost:3000). The backend API is available at [http://localhost:8000/chat](http://localhost:8000/chat).
 
-Build and start the services:
-
-```bash
-docker-compose up --build
-```
-
-Access the frontend at [http://localhost:3000](http://localhost:3000).
-The backend API will be available at [http://localhost:8000/chat](http://localhost:8000/chat).
+During development the containers mount the source code and run with hot reloading so changes are picked up immediately.
 
 ## Project Structure
 - `backend/` – FastAPI service
 - `frontend/` – Next.js application
 - `docker-compose.yml` – Docker orchestration file
+- `.env.example` – environment variable template
+- `CHANGELOG.md` – release notes

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.11-slim
-
+FROM python:3.11-slim AS builder
 WORKDIR /app
+COPY requirements.txt .
+RUN pip wheel --no-cache-dir -r requirements.txt -w /wheels
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY main.py ./
-
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/*
+COPY . .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,22 @@
+import os
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./chat.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class Message(Base):
+    __tablename__ = "messages"
+    id = Column(Integer, primary_key=True, index=True)
+    user_message = Column(String, nullable=False)
+    ai_response = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,14 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from dotenv import load_dotenv
+import openai
+import os
+from database import init_db, SessionLocal, Message
 
 app = FastAPI()
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 class ChatRequest(BaseModel):
     message: str
@@ -9,10 +16,29 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     response: str
 
+@app.on_event("startup")
+def startup_event():
+    init_db()
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
-    # Simple echo AI for demonstration
     if not request.message:
         raise HTTPException(status_code=400, detail="Message cannot be empty")
-    return ChatResponse(response=f"AI: {request.message}")
+    try:
+        if openai.api_key:
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": request.message}],
+            )
+            ai_text = resp.choices[0].message.content.strip()
+        else:
+            ai_text = f"I heard you say: {request.message}"
+    except Exception:
+        raise HTTPException(status_code=500, detail="AI generation failed")
 
+    db = SessionLocal()
+    msg = Message(user_message=request.message, ai_response=ai_text)
+    db.add(msg)
+    db.commit()
+    db.close()
+    return ChatResponse(response=ai_text)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,7 @@
 fastapi==0.110.0
 uvicorn==0.25.0
 pydantic==2.6.4
+
+openai==1.25.0
+python-dotenv==1.0.1
+sqlalchemy==2.0.29

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,21 @@ services:
     container_name: backend
     ports:
       - "8000:8000"
+    volumes:
+      - ./backend:/app
+    env_file:
+      - .env
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+
   frontend:
     build: ./frontend
     container_name: frontend
     ports:
       - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    env_file:
+      - .env
+    command: npm run dev
     depends_on:
       - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,18 @@
-FROM node:18-alpine
-
+FROM node:18-alpine AS deps
 WORKDIR /app
-
-COPY package.json ./
+COPY package.json .
 RUN npm install
 
-COPY pages ./pages
-
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 RUN npm run build
 
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app/.next .next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,32 +1,56 @@
 import { useState } from 'react'
 
 export default function Home() {
-  const [message, setMessage] = useState('')
-  const [response, setResponse] = useState('')
+  const [input, setInput] = useState('')
+  const [messages, setMessages] = useState([])
+  const [loading, setLoading] = useState(false)
 
   const sendMessage = async () => {
-    setResponse('...')
-    const res = await fetch('http://localhost:8000/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message })
-    })
-    const data = await res.json()
-    setResponse(data.response)
+    if (!input.trim()) return
+    const history = [...messages, { sender: 'user', text: input }]
+    setMessages(history)
+    setInput('')
+    setLoading(true)
+    try {
+      const res = await fetch('http://localhost:8000/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input })
+      })
+      if (!res.ok) throw new Error('Request failed')
+      const data = await res.json()
+      setMessages([...history, { sender: 'ai', text: data.response }])
+    } catch (err) {
+      setMessages([...history, { sender: 'ai', text: 'Error: ' + err.message }])
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
     <div style={{ padding: 20 }}>
       <h1>AI Assistant</h1>
+      <div style={{ maxWidth: 600, marginBottom: 20 }}>
+        {messages.map((m, i) => (
+          <div key={i} style={{ textAlign: m.sender === 'user' ? 'right' : 'left', margin: '5px 0' }}>
+            <span style={{
+              display: 'inline-block',
+              padding: '8px 12px',
+              borderRadius: 12,
+              background: m.sender === 'user' ? '#d1e7dd' : '#f8d7da'
+            }}>{m.text}</span>
+          </div>
+        ))}
+        {loading && <p>Typing...</p>}
+      </div>
       <textarea
         rows="4"
         cols="50"
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
       />
       <br />
-      <button onClick={sendMessage}>Send</button>
-      <p>{response}</p>
+      <button onClick={sendMessage} disabled={loading}>Send</button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add new CHANGELOG
- persist chat messages with SQLite
- call OpenAI API for responses when key available
- update frontend UI with chat bubbles and typing indicator
- switch to environment variables and multi-stage Docker builds
- add hot reloading via docker-compose config

## Testing
- `python -m py_compile backend/*.py`
- `npm ls` *(fails: missing dependencies, network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688268d0ac68832eaa49fdfe6d7b7592