### PR TITLE
Fix Next.js install conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
       - ./frontend:/app
     env_file:
       - .env
-    command: sh -c "npm install && npm run dev"
+    command: sh -c "rm -rf node_modules && npm install && npm run dev"
     depends_on:
       - backend


### PR DESCRIPTION
## Summary
- clear `node_modules` before running `npm install` for the frontend container

## Testing
- `docker-compose config` *(fails: `docker-compose`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826e310fbc832e9d4ad7d6e5cefbb8